### PR TITLE
Add sugar to call super methods in a MethodAssembly

### DIFF
--- a/src/main/kotlin/codes/som/anthony/koffee/sugar/ClassAssemblyExtension.kt
+++ b/src/main/kotlin/codes/som/anthony/koffee/sugar/ClassAssemblyExtension.kt
@@ -2,9 +2,8 @@ package codes.som.anthony.koffee.sugar
 
 import codes.som.anthony.koffee.ClassAssembly
 import codes.som.anthony.koffee.MethodAssembly
-import codes.som.anthony.koffee.insns.jvm.aload_0
-import codes.som.anthony.koffee.insns.jvm.invokespecial
 import codes.som.anthony.koffee.modifiers.Modifiers
+import codes.som.anthony.koffee.sugar.MethodAssemblyExtension.call_super
 import codes.som.anthony.koffee.types.TypeLike
 import org.objectweb.asm.tree.MethodNode
 import java.lang.IllegalArgumentException
@@ -19,9 +18,7 @@ object ClassAssemblyExtension {
         }
 
         return method(access, "<init>", void, *parameterTypes) {
-            aload_0 // load this
-            invokespecial(superClass, "<init>", void)
-
+            call_super(superClass)
             routine()
         }
     }

--- a/src/main/kotlin/codes/som/anthony/koffee/sugar/MethodAssemblyExtension.kt
+++ b/src/main/kotlin/codes/som/anthony/koffee/sugar/MethodAssemblyExtension.kt
@@ -1,0 +1,13 @@
+package codes.som.anthony.koffee.sugar
+
+import codes.som.anthony.koffee.MethodAssembly
+import codes.som.anthony.koffee.insns.jvm.aload_0
+import codes.som.anthony.koffee.insns.jvm.invokespecial
+import codes.som.anthony.koffee.types.TypeLike
+
+object MethodAssemblyExtension {
+    fun MethodAssembly.call_super(superClass: TypeLike = Object::class, name: String = "<init>") {
+        aload_0 // load this
+        invokespecial(superClass, name, void)
+    }
+}

--- a/src/main/kotlin/codes/som/anthony/koffee/sugar/MethodAssemblyExtension.kt
+++ b/src/main/kotlin/codes/som/anthony/koffee/sugar/MethodAssemblyExtension.kt
@@ -6,8 +6,8 @@ import codes.som.anthony.koffee.insns.jvm.invokespecial
 import codes.som.anthony.koffee.types.TypeLike
 
 object MethodAssemblyExtension {
-    fun MethodAssembly.call_super(superClass: TypeLike = Object::class, name: String = "<init>") {
+    fun MethodAssembly.call_super(superClass: TypeLike = Object::class, name: String = "<init>", returnType: TypeLike = void) {
         aload_0 // load this
-        invokespecial(superClass, name, void)
+        invokespecial(superClass, name, returnType)
     }
 }


### PR DESCRIPTION
This greatly simplifies situations that require calling superclass methods, such as during initialisation.